### PR TITLE
Update noPac.py

### DIFF
--- a/noPac.py
+++ b/noPac.py
@@ -97,7 +97,7 @@ def samtheadmin(username, password, domain, options):
     cnf.basepath = None
     domain_dumper = ldapdomaindump.domainDumper(ldap_server, ldap_session, cnf)
     check_domain = ".".join(domain_dumper.getRoot().replace("DC=", "").split(","))
-    if domain != check_domain:
+    if domain != check_domain and domain.upper() != check_domain:
         logging.error("Pls use full domain name, such as: domain.com/username")
         return
     MachineAccountQuota = 10


### PR DESCRIPTION
Include uppercase variant of 'domain' in conditional on line 100 since 'namingcontexts' for 'DC=*' via ldap reply is in uppercase. I figure this line is 'script kiddie proof', and may also teach those learning the industry(such as myself) to diagnose why a tool isn't working. I figured it wouldn't hurt to suggest it. Awesome tool, by the way.